### PR TITLE
Added stape store option and logging

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: 50c0e2463dc21b4ce35f57acad4db8b33662eae6
-    changeNotes: Add only restore cookie option.
-  - sha: aea50a0785fa0f5a439fa3a9a3c49307346fa78d
-    changeNotes: Initial release.
+- sha: 8dba30f43cf48d6f1414469058728ef46315dd50
+  changeNotes: Added stape store option and logging.
+- sha: 50c0e2463dc21b4ce35f57acad4db8b33662eae6
+  changeNotes: Add only restore cookie option.
+- sha: aea50a0785fa0f5a439fa3a9a3c49307346fa78d
+  changeNotes: Initial release.

--- a/template.js
+++ b/template.js
@@ -1,118 +1,277 @@
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
 const Firestore = require('Firestore');
+const getRequestHeader = require('getRequestHeader');
+const sendHttpRequest = require('sendHttpRequest');
+const JSON = require('JSON');
+const encodeUriComponent = require('encodeUriComponent');
+const logToConsole = require('logToConsole');
+const getContainerVersion = require('getContainerVersion');
+const Object = require('Object');
+
+let storeUrl = getStoreUrl();
+let documentKey = 'cookie_restore';
+let storeDocumentUrl = storeUrl + '/' + enc(documentKey);
+const isLoggingEnabled = determinateIsLoggingEnabled();
 
 const identifiersValues = getIdentifiersValues(data.identifiers);
 if (identifiersValues.length === 0) {
+  data.gtmOnSuccess();
+
+  return;
+}
+
+let firebaseOptions = { limit: 1 };
+if (data.flowType === 'firebase') {
+  if (data.firebaseProjectId)
+    firebaseOptions.projectId = data.firebaseProjectId;
+  Firestore.query(
+    data.firebasePath,
+    [['identifiersValues', 'array-contains-any', identifiersValues]],
+    firebaseOptions,
+  ).then(
+    (documents) => {
+      return restoreCookies(
+        documents && documents.length > 0 ? documents[0] : {},
+      );
+    },
+    () => {
+      return restoreCookies({});
+    },
+  );
+} else {
+  sendHttpRequest(storeDocumentUrl, { method: 'GET' }).then((documents) => {
+    let body = JSON.parse(documents.body);
+    let identifiers = body.data ? Object.keys(body.data) : [];
+    log({
+      Name: 'CookieRestore',
+      Type: 'Response',
+      TraceId: '',
+      EventName: 'CookieRestoreGET',
+      RequestMethod: 'GET',
+      RequestUrl: storeUrl,
+      RequestBody: documents.body,
+    });
+    let preparedData = prepareStapeStoreData(body.data, data.identifiers);
+    return restoreCookies({
+      data: preparedData,
+      identifiers: identifiers,
+      stapeStoreData: body.data,
+    });
+  });
+}
+
+function restoreCookies(document) {
+  let storedData = document.data || {};
+  let mergedIdentifiers = mergeIdentifiers(
+    storedData.identifiers,
+    data.identifiers,
+  );
+  let cookiesToStore = {};
+
+  if (data.cookies && data.cookies.length > 0) {
+    data.cookies.forEach(function (cookieObject) {
+      let cookies = getCookieValues(cookieObject.name, true);
+
+      if (cookies && cookies.length > 0) {
+        cookiesToStore[cookieObject.name] = cookies;
+      } else if (storedData.cookies && storedData.cookies[cookieObject.name]) {
+        setCookieFunc(cookieObject, storedData.cookies[cookieObject.name][0]);
+        cookiesToStore[cookieObject.name] =
+          storedData.cookies[cookieObject.name];
+      }
+    });
+  }
+
+  if (getObjectLength(cookiesToStore) === 0 || data.onlyRestore) {
     data.gtmOnSuccess();
 
     return;
-}
+  }
 
-let firebaseOptions = {limit: 1};
-if (data.firebaseProjectId) firebaseOptions.projectId = data.firebaseProjectId;
-
-Firestore.query(data.firebasePath, [['identifiersValues', 'array-contains-any', identifiersValues]], firebaseOptions)
-    .then((documents) => {
-        return restoreCookies(documents && documents.length > 0 ? documents[0] : {});
-    }, () => {
-        return restoreCookies({});
+  if (data.flowType === 'firebase') {
+    let cookiesDataToStore = {
+      identifiers: mergedIdentifiers,
+      identifiersValues: getIdentifiersValues(mergedIdentifiers),
+      cookies: cookiesToStore,
+    };
+    Firestore.write(
+      document.id || data.firebasePath,
+      cookiesDataToStore,
+      firebaseOptions,
+    ).then(() => {
+      data.gtmOnSuccess();
+    }, data.gtmOnFailure);
+  } else {
+    let stapeStoreData = document.stapeStoreData || {};
+    mergedIdentifiers.forEach(function (identifier) {
+      if (!stapeStoreData[identifier.name]) {
+        stapeStoreData[identifier.name] = {};
+      }
+      stapeStoreData[identifier.name][identifier.value] = cookiesToStore;
     });
 
-function restoreCookies(document) {
-    let storedData = document.data || {};
-    let cookiesToStore = {};
-
-    if (data.cookies && data.cookies.length > 0) {
-        data.cookies.forEach(function (cookieObject) {
-            let cookies = getCookieValues(cookieObject.name, true);
-
-            if (cookies && cookies.length > 0) {
-                cookiesToStore[cookieObject.name] = cookies;
-            } else if (storedData.cookies && storedData.cookies[cookieObject.name]) {
-                storedData.cookies[cookieObject.name].forEach(function (cookie) {
-                    setCookie(cookieObject.name, cookie, {
-                        domain: 'auto',
-                        path: '/',
-                        samesite: 'Lax',
-                        secure: true,
-                        'max-age': cookieObject.lifetime,
-                        httpOnly: false
-                    }, true);
-                });
-
-                cookiesToStore[cookieObject.name] = storedData.cookies[cookieObject.name];
-            }
-        });
-    }
-
-    if (getObjectLength(cookiesToStore) === 0 || data.onlyRestore) {
+    sendHttpRequest(
+      storeDocumentUrl,
+      { method: 'PUT', headers: { 'Content-Type': 'application/json' } },
+      JSON.stringify(stapeStoreData),
+    ).then(function (response) {
+      let statusCode = response.statusCode;
+      log({
+        Name: 'CookierRestore',
+        Type: 'Response',
+        TraceId: '',
+        EventName: 'CookierRestorePUT',
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: {},
+        ResponseBody: JSON.stringify(response),
+      });
+      if (statusCode >= 200 && statusCode < 300) {
         data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    });
+  }
+}
 
-        return;
-    }
-
-    let mergedIdentifiers = mergeIdentifiers(storedData.identifiers, data.identifiers);
-    let cookiesDataToStore = {
-        identifiers: mergedIdentifiers,
-        identifiersValues: getIdentifiersValues(mergedIdentifiers),
-        cookies: cookiesToStore,
-    };
-
-    Firestore.write(document.id || data.firebasePath, cookiesDataToStore, firebaseOptions)
-        .then(() => {
-            data.gtmOnSuccess();
-        }, data.gtmOnFailure);
+function setCookieFunc(cookieObject, cookieData) {
+  setCookie(
+    cookieObject.name,
+    cookieData,
+    {
+      domain: 'auto',
+      path: '/',
+      samesite: 'Lax',
+      secure: true,
+      'max-age': cookieObject.lifetime,
+      httpOnly: false,
+    },
+    true,
+  );
 }
 
 function getIdentifiersValues(identifiers) {
-    let identifiersValues = [];
+  let identifiersValues = [];
 
-    if (identifiers && identifiers.length > 0) {
-        identifiers.forEach(function (identifier) {
-            if (identifier.value) {
-                identifiersValues.push(identifier.value);
-            }
-        });
-    }
+  if (identifiers && identifiers.length > 0) {
+    identifiers.forEach(function (identifier) {
+      if (identifier.value) {
+        identifiersValues.push(identifier.value);
+      }
+    });
+  }
 
-    return identifiersValues;
+  return identifiersValues;
 }
 
 function mergeIdentifiers(oldIdentifiers, newIdentifiers) {
-    let identifiers = [];
+  let identifiers = [];
 
-    if (oldIdentifiers && oldIdentifiers.length > 0) {
-        identifiers = oldIdentifiers;
-    }
+  if (oldIdentifiers && oldIdentifiers.length > 0) {
+    identifiers = oldIdentifiers;
+  }
 
-    if (newIdentifiers && newIdentifiers.length > 0) {
-        newIdentifiers.forEach(function (newIdentifier) {
-            let identifierFound = false;
+  if (newIdentifiers && newIdentifiers.length > 0) {
+    newIdentifiers.forEach(function (newIdentifier) {
+      let identifierFound = false;
 
-            identifiers.forEach(function (identifier) {
-                if (identifier.name === newIdentifier.name && newIdentifier.value) {
-                    identifier.value = newIdentifier.value;
-                    identifierFound = true;
-                }
-            });
+      identifiers.forEach(function (identifier) {
+        if (identifier.name === newIdentifier.name && newIdentifier.value) {
+          identifier.value = newIdentifier.value;
+          identifierFound = true;
+        }
+      });
 
-            if (!identifierFound && newIdentifier.value) {
-                identifiers.push(newIdentifier);
-            }
-        });
-    }
+      if (!identifierFound && newIdentifier.value) {
+        identifiers.push(newIdentifier);
+      }
+    });
+  }
 
-    return identifiers;
+  return identifiers;
 }
 
 function getObjectLength(object) {
-    let length = 0;
+  let length = 0;
 
-    for (let key in object) {
-        if (object.hasOwnProperty(key)) {
-            ++length;
-        }
+  for (let key in object) {
+    if (object.hasOwnProperty(key)) {
+      ++length;
     }
-    return length;
+  }
+  return length;
+}
+
+function prepareStapeStoreData(bodyData, identifiers) {
+  let cookies = {};
+  let addedIdentifiers = {};
+
+  if (bodyData) {
+    identifiers.forEach(function (identifier) {
+      if (
+        bodyData[identifier.name] &&
+        bodyData[identifier.name][identifier.value]
+      ) {
+        addedIdentifiers[identifier.name] = identifier.value;
+        let cookieList = Object.keys(
+          bodyData[identifier.name][identifier.value],
+        );
+        cookieList.forEach(function (cookieName) {
+          cookies[cookieName] =
+            bodyData[identifier.name][identifier.value][cookieName];
+        });
+      }
+    });
+  }
+  return { cookies: cookies, identifiers: addedIdentifiers };
+}
+
+function getStoreUrl() {
+  const containerIdentifier = getRequestHeader('x-gtm-identifier');
+  const defaultDomain = getRequestHeader('x-gtm-default-domain');
+  const containerApiKey = getRequestHeader('x-gtm-api-key');
+
+  return (
+    'https://' +
+    enc(containerIdentifier) +
+    '.' +
+    enc(defaultDomain) +
+    '/stape-api/' +
+    enc(containerApiKey) +
+    '/v1/store'
+  );
+}
+
+function enc(data) {
+  data = data || '';
+  return encodeUriComponent(data);
+}
+
+function log(logObject) {
+  if (isLoggingEnabled) {
+    logToConsole(JSON.stringify(logObject));
+  }
+}
+
+function determinateIsLoggingEnabled() {
+  const containerVersion = getContainerVersion();
+  const isDebug = !!(
+    containerVersion &&
+    (containerVersion.debugMode || containerVersion.previewMode)
+  );
+
+  if (!data.logType) {
+    return isDebug;
+  }
+
+  if (data.logType === 'no') {
+    return false;
+  }
+
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
+
+  return data.logType === 'always';
 }

--- a/template.js
+++ b/template.js
@@ -8,11 +8,13 @@ const encodeUriComponent = require('encodeUriComponent');
 const logToConsole = require('logToConsole');
 const getContainerVersion = require('getContainerVersion');
 const Object = require('Object');
+const makeString = require('makeString');
+const generateRandom = require('generateRandom');
+const getTimestampMillis = require('getTimestampMillis');
 
-let storeUrl = getStoreUrl();
-let documentKey = 'cookie_restore';
-let storeDocumentUrl = storeUrl + '/' + enc(documentKey);
 const isLoggingEnabled = determinateIsLoggingEnabled();
+const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
+const storeUrl = getStoreUrl();
 
 const identifiersValues = getIdentifiersValues(data.identifiers);
 if (identifiersValues.length === 0) {
@@ -40,24 +42,31 @@ if (data.flowType === 'firebase') {
     },
   );
 } else {
-  sendHttpRequest(storeDocumentUrl, { method: 'GET' }).then((documents) => {
+  let filters = getStoreFilter(identifiersValues);
+  sendHttpRequest(
+    storeUrl,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' } },
+    JSON.stringify({
+      limit: 1,
+      data: filters,
+    }),
+  ).then((documents) => {
     let body = JSON.parse(documents.body);
-    let identifiers = body.data ? Object.keys(body.data) : [];
+    let preparedData = { data: {}, key: '' };
+    if (body && body.length > 0) {
+      preparedData = body[0].data;
+      preparedData.key = body[0].key;
+    }
     log({
       Name: 'CookieRestore',
       Type: 'Response',
-      TraceId: '',
-      EventName: 'CookieRestoreGET',
-      RequestMethod: 'GET',
+      TraceId: traceId,
+      EventName: 'CookieRestorePOST',
+      RequestMethod: 'POST',
       RequestUrl: storeUrl,
-      RequestBody: documents.body,
+      RequestBody: documents,
     });
-    let preparedData = prepareStapeStoreData(body.data, data.identifiers);
-    return restoreCookies({
-      data: preparedData,
-      identifiers: identifiers,
-      stapeStoreData: body.data,
-    });
+    return restoreCookies({ data: preparedData });
   });
 }
 
@@ -88,13 +97,12 @@ function restoreCookies(document) {
 
     return;
   }
-
+  let cookiesDataToStore = {
+    identifiers: mergedIdentifiers,
+    identifiersValues: getIdentifiersValues(mergedIdentifiers),
+    cookies: cookiesToStore,
+  };
   if (data.flowType === 'firebase') {
-    let cookiesDataToStore = {
-      identifiers: mergedIdentifiers,
-      identifiersValues: getIdentifiersValues(mergedIdentifiers),
-      cookies: cookiesToStore,
-    };
     Firestore.write(
       document.id || data.firebasePath,
       cookiesDataToStore,
@@ -103,24 +111,18 @@ function restoreCookies(document) {
       data.gtmOnSuccess();
     }, data.gtmOnFailure);
   } else {
-    let stapeStoreData = document.stapeStoreData || {};
-    mergedIdentifiers.forEach(function (identifier) {
-      if (!stapeStoreData[identifier.name]) {
-        stapeStoreData[identifier.name] = {};
-      }
-      stapeStoreData[identifier.name][identifier.value] = cookiesToStore;
-    });
-
+    let documentKey = storedData.key || generateDocumentKey();
+    let storeDocumentUrl = storeUrl + '/' + enc(documentKey);
     sendHttpRequest(
       storeDocumentUrl,
       { method: 'PUT', headers: { 'Content-Type': 'application/json' } },
-      JSON.stringify(stapeStoreData),
+      JSON.stringify(cookiesDataToStore),
     ).then(function (response) {
       let statusCode = response.statusCode;
       log({
         Name: 'CookierRestore',
         Type: 'Response',
-        TraceId: '',
+        TraceId: traceId,
         EventName: 'CookierRestorePUT',
         ResponseStatusCode: statusCode,
         ResponseHeaders: {},
@@ -133,6 +135,15 @@ function restoreCookies(document) {
       }
     });
   }
+}
+
+function getStoreFilter(values) {
+  return [['identifiersValues', 'array-contains-any', values]];
+}
+
+function generateDocumentKey() {
+  const rnd = makeString(generateRandom(1000000000, 2147483647));
+  return 'cookie_' + makeString(getTimestampMillis()) + rnd;
 }
 
 function setCookieFunc(cookieObject, cookieData) {
@@ -201,30 +212,6 @@ function getObjectLength(object) {
     }
   }
   return length;
-}
-
-function prepareStapeStoreData(bodyData, identifiers) {
-  let cookies = {};
-  let addedIdentifiers = {};
-
-  if (bodyData) {
-    identifiers.forEach(function (identifier) {
-      if (
-        bodyData[identifier.name] &&
-        bodyData[identifier.name][identifier.value]
-      ) {
-        addedIdentifiers[identifier.name] = identifier.value;
-        let cookieList = Object.keys(
-          bodyData[identifier.name][identifier.value],
-        );
-        cookieList.forEach(function (cookieName) {
-          cookies[cookieName] =
-            bodyData[identifier.name][identifier.value][cookieName];
-        });
-      }
-    });
-  }
-  return { cookies: cookies, identifiers: addedIdentifiers };
 }
 
 function getStoreUrl() {

--- a/template.tpl
+++ b/template.tpl
@@ -220,11 +220,13 @@ const encodeUriComponent = require('encodeUriComponent');
 const logToConsole = require('logToConsole');
 const getContainerVersion = require('getContainerVersion');
 const Object = require('Object');
+const makeString = require('makeString');
+const generateRandom = require('generateRandom');
+const getTimestampMillis = require('getTimestampMillis');
 
-let storeUrl = getStoreUrl();
-let documentKey = 'cookie_restore';
-let storeDocumentUrl = storeUrl + '/' + enc(documentKey);
 const isLoggingEnabled = determinateIsLoggingEnabled();
+const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
+const storeUrl = getStoreUrl();
 
 const identifiersValues = getIdentifiersValues(data.identifiers);
 if (identifiersValues.length === 0) {
@@ -252,24 +254,31 @@ if (data.flowType === 'firebase') {
     },
   );
 } else {
-  sendHttpRequest(storeDocumentUrl, { method: 'GET' }).then((documents) => {
+  let filters = getStoreFilter(identifiersValues);
+  sendHttpRequest(
+    storeUrl,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' } },
+    JSON.stringify({
+      limit: 1,
+      data: filters,
+    }),
+  ).then((documents) => {
     let body = JSON.parse(documents.body);
-    let identifiers = body.data ? Object.keys(body.data) : [];
+    let preparedData = { data: {}, key: '' };
+    if (body && body.length > 0) {
+      preparedData = body[0].data;
+      preparedData.key = body[0].key;
+    }
     log({
       Name: 'CookieRestore',
       Type: 'Response',
-      TraceId: '',
-      EventName: 'CookieRestoreGET',
-      RequestMethod: 'GET',
+      TraceId: traceId,
+      EventName: 'CookieRestorePOST',
+      RequestMethod: 'POST',
       RequestUrl: storeUrl,
-      RequestBody: documents.body,
+      RequestBody: documents,
     });
-    let preparedData = prepareStapeStoreData(body.data, data.identifiers);
-    return restoreCookies({
-      data: preparedData,
-      identifiers: identifiers,
-      stapeStoreData: body.data,
-    });
+    return restoreCookies({ data: preparedData });
   });
 }
 
@@ -300,13 +309,12 @@ function restoreCookies(document) {
 
         return;
     }
-
-  if (data.flowType === 'firebase') {
     let cookiesDataToStore = {
         identifiers: mergedIdentifiers,
         identifiersValues: getIdentifiersValues(mergedIdentifiers),
         cookies: cookiesToStore,
     };
+  if (data.flowType === 'firebase') {
     Firestore.write(
       document.id || data.firebasePath,
       cookiesDataToStore,
@@ -315,24 +323,18 @@ function restoreCookies(document) {
             data.gtmOnSuccess();
         }, data.gtmOnFailure);
   } else {
-    let stapeStoreData = document.stapeStoreData || {};
-    mergedIdentifiers.forEach(function (identifier) {
-      if (!stapeStoreData[identifier.name]) {
-        stapeStoreData[identifier.name] = {};
-      }
-      stapeStoreData[identifier.name][identifier.value] = cookiesToStore;
-    });
-
+    let documentKey = storedData.key || generateDocumentKey();
+    let storeDocumentUrl = storeUrl + '/' + enc(documentKey);
     sendHttpRequest(
       storeDocumentUrl,
       { method: 'PUT', headers: { 'Content-Type': 'application/json' } },
-      JSON.stringify(stapeStoreData),
+      JSON.stringify(cookiesDataToStore),
     ).then(function (response) {
       let statusCode = response.statusCode;
       log({
         Name: 'CookierRestore',
         Type: 'Response',
-        TraceId: '',
+        TraceId: traceId,
         EventName: 'CookierRestorePUT',
         ResponseStatusCode: statusCode,
         ResponseHeaders: {},
@@ -345,6 +347,15 @@ function restoreCookies(document) {
       }
     });
   }
+}
+
+function getStoreFilter(values) {
+  return [['identifiersValues', 'array-contains-any', values]];
+}
+
+function generateDocumentKey() {
+  const rnd = makeString(generateRandom(1000000000, 2147483647));
+  return 'cookie_' + makeString(getTimestampMillis()) + rnd;
 }
 
 function setCookieFunc(cookieObject, cookieData) {
@@ -413,30 +424,6 @@ function getObjectLength(object) {
         }
     }
     return length;
-}
-
-function prepareStapeStoreData(bodyData, identifiers) {
-  let cookies = {};
-  let addedIdentifiers = {};
-
-  if (bodyData) {
-    identifiers.forEach(function (identifier) {
-      if (
-        bodyData[identifier.name] &&
-        bodyData[identifier.name][identifier.value]
-      ) {
-        addedIdentifiers[identifier.name] = identifier.value;
-        let cookieList = Object.keys(
-          bodyData[identifier.name][identifier.value],
-        );
-        cookieList.forEach(function (cookieName) {
-          cookies[cookieName] =
-            bodyData[identifier.name][identifier.value][cookieName];
-        });
-      }
-    });
-  }
-  return { cookies: cookies, identifiers: addedIdentifiers };
 }
 
 function getStoreUrl() {
@@ -697,6 +684,21 @@ ___SERVER_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "x-gtm-api-key"
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "headerName"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "trace-id"
                   }
                 ]
               }

--- a/template.tpl
+++ b/template.tpl
@@ -30,6 +30,22 @@ ___TEMPLATE_PARAMETERS___
 
 [
   {
+    "type": "RADIO",
+    "name": "flowType",
+    "radioItems": [
+      {
+        "value": "stape",
+        "displayValue": "Stape store"
+      },
+      {
+        "value": "firebase",
+        "displayValue": "Firebase"
+      }
+    ],
+    "simpleValueType": true,
+    "defaultValue": "stape"
+  },
+  {
     "type": "GROUP",
     "name": "firebaseGroup",
     "groupStyle": "NO_ZIPPY",
@@ -54,7 +70,14 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true
       }
     ],
-    "displayName": "Firebase Settings"
+    "displayName": "Firebase Settings",
+    "enablingConditions": [
+      {
+        "paramName": "flowType",
+        "paramValue": "firebase",
+        "type": "EQUALS"
+      }
+    ]
   },
   {
     "type": "CHECKBOX",
@@ -153,6 +176,34 @@ ___TEMPLATE_PARAMETERS___
       }
     ],
     "help": "\u003cb\u003eCookie lifetime examples:\u003c/b\u003e\u003cbr\u003e 2 years \u003d 63072000 seconds \u003cbr\u003e1 year \u003d 31536000 seconds \u003cbr\u003e6 month \u003d 15780000 seconds \u003cbr\u003e3 month \u003d 7890000 seconds \u003cbr\u003e1 month \u003d 2630000 seconds \u003cbr\u003e2 weeks \u003d 1209600 seconds"
+  },
+  {
+    "type": "GROUP",
+    "name": "logsGroup",
+    "displayName": "Logs Settings",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "logType",
+        "radioItems": [
+          {
+            "value": "no",
+            "displayValue": "Do not log"
+          },
+          {
+            "value": "debug",
+            "displayValue": "Log to console during debug and preview"
+          },
+          {
+            "value": "always",
+            "displayValue": "Always log to console"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "debug"
+      }
+    ]
   }
 ]
 
@@ -162,6 +213,18 @@ ___SANDBOXED_JS_FOR_SERVER___
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
 const Firestore = require('Firestore');
+const getRequestHeader = require('getRequestHeader');
+const sendHttpRequest = require('sendHttpRequest');
+const JSON = require('JSON');
+const encodeUriComponent = require('encodeUriComponent');
+const logToConsole = require('logToConsole');
+const getContainerVersion = require('getContainerVersion');
+const Object = require('Object');
+
+let storeUrl = getStoreUrl();
+let documentKey = 'cookie_restore';
+let storeDocumentUrl = storeUrl + '/' + enc(documentKey);
+const isLoggingEnabled = determinateIsLoggingEnabled();
 
 const identifiersValues = getIdentifiersValues(data.identifiers);
 if (identifiersValues.length === 0) {
@@ -170,18 +233,52 @@ if (identifiersValues.length === 0) {
     return;
 }
 
-let firebaseOptions = {limit: 1};
-if (data.firebaseProjectId) firebaseOptions.projectId = data.firebaseProjectId;
-
-Firestore.query(data.firebasePath, [['identifiersValues', 'array-contains-any', identifiersValues]], firebaseOptions)
-    .then((documents) => {
-        return restoreCookies(documents && documents.length > 0 ? documents[0] : {});
-    }, () => {
+let firebaseOptions = { limit: 1 };
+if (data.flowType === 'firebase') {
+  if (data.firebaseProjectId)
+    firebaseOptions.projectId = data.firebaseProjectId;
+  Firestore.query(
+    data.firebasePath,
+    [['identifiersValues', 'array-contains-any', identifiersValues]],
+    firebaseOptions,
+  ).then(
+    (documents) => {
+      return restoreCookies(
+        documents && documents.length > 0 ? documents[0] : {},
+      );
+    },
+    () => {
         return restoreCookies({});
+    },
+  );
+} else {
+  sendHttpRequest(storeDocumentUrl, { method: 'GET' }).then((documents) => {
+    let body = JSON.parse(documents.body);
+    let identifiers = body.data ? Object.keys(body.data) : [];
+    log({
+      Name: 'CookieRestore',
+      Type: 'Response',
+      TraceId: '',
+      EventName: 'CookieRestoreGET',
+      RequestMethod: 'GET',
+      RequestUrl: storeUrl,
+      RequestBody: documents.body,
     });
+    let preparedData = prepareStapeStoreData(body.data, data.identifiers);
+    return restoreCookies({
+      data: preparedData,
+      identifiers: identifiers,
+      stapeStoreData: body.data,
+    });
+  });
+}
 
 function restoreCookies(document) {
     let storedData = document.data || {};
+  let mergedIdentifiers = mergeIdentifiers(
+    storedData.identifiers,
+    data.identifiers,
+  );
     let cookiesToStore = {};
 
     if (data.cookies && data.cookies.length > 0) {
@@ -191,18 +288,9 @@ function restoreCookies(document) {
             if (cookies && cookies.length > 0) {
                 cookiesToStore[cookieObject.name] = cookies;
             } else if (storedData.cookies && storedData.cookies[cookieObject.name]) {
-                storedData.cookies[cookieObject.name].forEach(function (cookie) {
-                    setCookie(cookieObject.name, cookie, {
-                        domain: 'auto',
-                        path: '/',
-                        samesite: 'Lax',
-                        secure: true,
-                        'max-age': cookieObject.lifetime,
-                        httpOnly: false
-                    }, true);
-                });
-
-                cookiesToStore[cookieObject.name] = storedData.cookies[cookieObject.name];
+        setCookieFunc(cookieObject, storedData.cookies[cookieObject.name][0]);
+        cookiesToStore[cookieObject.name] =
+          storedData.cookies[cookieObject.name];
             }
         });
     }
@@ -213,17 +301,66 @@ function restoreCookies(document) {
         return;
     }
 
-    let mergedIdentifiers = mergeIdentifiers(storedData.identifiers, data.identifiers);
+  if (data.flowType === 'firebase') {
     let cookiesDataToStore = {
         identifiers: mergedIdentifiers,
         identifiersValues: getIdentifiersValues(mergedIdentifiers),
         cookies: cookiesToStore,
     };
-
-    Firestore.write(document.id || data.firebasePath, cookiesDataToStore, firebaseOptions)
-        .then(() => {
+    Firestore.write(
+      document.id || data.firebasePath,
+      cookiesDataToStore,
+      firebaseOptions,
+    ).then(() => {
             data.gtmOnSuccess();
         }, data.gtmOnFailure);
+  } else {
+    let stapeStoreData = document.stapeStoreData || {};
+    mergedIdentifiers.forEach(function (identifier) {
+      if (!stapeStoreData[identifier.name]) {
+        stapeStoreData[identifier.name] = {};
+      }
+      stapeStoreData[identifier.name][identifier.value] = cookiesToStore;
+    });
+
+    sendHttpRequest(
+      storeDocumentUrl,
+      { method: 'PUT', headers: { 'Content-Type': 'application/json' } },
+      JSON.stringify(stapeStoreData),
+    ).then(function (response) {
+      let statusCode = response.statusCode;
+      log({
+        Name: 'CookierRestore',
+        Type: 'Response',
+        TraceId: '',
+        EventName: 'CookierRestorePUT',
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: {},
+        ResponseBody: JSON.stringify(response),
+      });
+      if (statusCode >= 200 && statusCode < 300) {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    });
+  }
+}
+
+function setCookieFunc(cookieObject, cookieData) {
+  setCookie(
+    cookieObject.name,
+    cookieData,
+    {
+      domain: 'auto',
+      path: '/',
+      samesite: 'Lax',
+      secure: true,
+      'max-age': cookieObject.lifetime,
+      httpOnly: false,
+    },
+    true,
+  );
 }
 
 function getIdentifiersValues(identifiers) {
@@ -278,6 +415,79 @@ function getObjectLength(object) {
     return length;
 }
 
+function prepareStapeStoreData(bodyData, identifiers) {
+  let cookies = {};
+  let addedIdentifiers = {};
+
+  if (bodyData) {
+    identifiers.forEach(function (identifier) {
+      if (
+        bodyData[identifier.name] &&
+        bodyData[identifier.name][identifier.value]
+      ) {
+        addedIdentifiers[identifier.name] = identifier.value;
+        let cookieList = Object.keys(
+          bodyData[identifier.name][identifier.value],
+        );
+        cookieList.forEach(function (cookieName) {
+          cookies[cookieName] =
+            bodyData[identifier.name][identifier.value][cookieName];
+        });
+      }
+    });
+  }
+  return { cookies: cookies, identifiers: addedIdentifiers };
+}
+
+function getStoreUrl() {
+  const containerIdentifier = getRequestHeader('x-gtm-identifier');
+  const defaultDomain = getRequestHeader('x-gtm-default-domain');
+  const containerApiKey = getRequestHeader('x-gtm-api-key');
+
+  return (
+    'https://' +
+    enc(containerIdentifier) +
+    '.' +
+    enc(defaultDomain) +
+    '/stape-api/' +
+    enc(containerApiKey) +
+    '/v1/store'
+  );
+}
+
+function enc(data) {
+  data = data || '';
+  return encodeUriComponent(data);
+}
+
+function log(logObject) {
+  if (isLoggingEnabled) {
+    logToConsole(JSON.stringify(logObject));
+  }
+}
+
+function determinateIsLoggingEnabled() {
+  const containerVersion = getContainerVersion();
+  const isDebug = !!(
+    containerVersion &&
+    (containerVersion.debugMode || containerVersion.previewMode)
+  );
+
+  if (!data.logType) {
+    return isDebug;
+  }
+
+  if (data.logType === 'no') {
+    return false;
+  }
+
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
+
+  return data.logType === 'always';
+}
+
 
 ___SERVER_PERMISSIONS___
 
@@ -329,6 +539,10 @@ ___SERVER_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "operation"
+                  },
+                  {
+                    "type": 1,
+                    "string": "databaseId"
                   }
                 ],
                 "mapValue": [
@@ -343,6 +557,10 @@ ___SERVER_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "read_write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "(default)"
                   }
                 ]
               }
@@ -422,6 +640,165 @@ ___SERVER_PERMISSIONS___
     },
     "clientAnnotations": {
       "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "read_request",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "headerWhitelist",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "headerName"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "x-gtm-identifier"
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "headerName"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "x-gtm-default-domain"
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "headerName"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "x-gtm-api-key"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "headersAllowed",
+          "value": {
+            "type": 8,
+            "boolean": true
+          }
+        },
+        {
+          "key": "requestAccess",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        },
+        {
+          "key": "headerAccess",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        },
+        {
+          "key": "queryParameterAccess",
+          "value": {
+            "type": 1,
+            "string": "any"
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "send_http",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "allowedUrls",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        },
+        {
+          "key": "urls",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 1,
+                "string": "https://*.stape.io/"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "logging",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "environments",
+          "value": {
+            "type": 1,
+            "string": "debug"
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "read_container_data",
+        "versionId": "1"
+      },
+      "param": []
     },
     "isRequired": true
   }


### PR DESCRIPTION
Changes:
- added stape store option
- added logging

Saving cookies in stape store under document "cookie_restore":
![image](https://github.com/user-attachments/assets/640228fc-128f-4f15-814f-01863bca5225)

Not sure what option is better, save everything in one document or create document for every new identifier or user? 
In firestore it creates everytime new document:
![image](https://github.com/user-attachments/assets/c1c3680c-4c94-485f-8ae7-2a62a88e84fc)
